### PR TITLE
RA-23-get-recipe-in-vm-androidviewmodel-favorites-refactor

### DIFF
--- a/app/src/main/java/com/example/myrecipebook/Constants.kt
+++ b/app/src/main/java/com/example/myrecipebook/Constants.kt
@@ -1,8 +1,8 @@
 package com.example.myrecipebook
 
-const val ARG_RECIPE = "recipe"
 const val ARG_CATEGORY_ID = "category_id"
 const val ARG_CATEGORY_NAME = "category_name"
 const val ARG_CATEGORY_IMAGE_URL = "category_image_url"
 const val PREFS_NAME = "MyRecipeBookPrefs"
 const val FAVORITES_KEY = "favorites"
+const val ARG_RECIPE_ID = "recipe_id"

--- a/app/src/main/java/com/example/myrecipebook/ui/recipes/favorite/FavoritesFragment.kt
+++ b/app/src/main/java/com/example/myrecipebook/ui/recipes/favorite/FavoritesFragment.kt
@@ -11,7 +11,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.example.myrecipebook.ARG_RECIPE
+import com.example.myrecipebook.ARG_RECIPE_ID
 import com.example.myrecipebook.FAVORITES_KEY
 import com.example.myrecipebook.PREFS_NAME
 import com.example.myrecipebook.R
@@ -24,19 +24,23 @@ import java.io.IOException
 class FavoritesFragment : Fragment() {
     private var _binding: FragmentFavoritesBinding? = null
     private val binding
-        get() = _binding
-            ?: throw IllegalStateException("Binding for FragmentFavoritesBinding must not be null")
+        get() =
+            _binding
+                ?: throw IllegalStateException("Binding for FragmentFavoritesBinding must not be null")
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View {
         _binding = FragmentFavoritesBinding.inflate(inflater, container, false)
         return binding.root
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
         super.onViewCreated(view, savedInstanceState)
         binding.tvFragmentTitle.text = getString(R.string.title_favorites)
         initRecycler()
@@ -50,12 +54,10 @@ class FavoritesFragment : Fragment() {
             binding.ivFavorite.setImageDrawable(drawable)
         } catch (e: IOException) {
             Log.e("FavoritesFragment", "Error loading header image", e)
-
         }
     }
 
     private fun initRecycler() {
-
         val favoritesIds = getFavorites().map { it.toInt() }.toSet()
 
         val favoriteRecipes = STUB.getRecipesByIds(favoritesIds)
@@ -71,11 +73,13 @@ class FavoritesFragment : Fragment() {
             binding.rvRecipes.layoutManager = LinearLayoutManager(context)
             binding.rvRecipes.adapter = adapter
 
-            adapter.setOnItemClickListener(object : RecipesListAdapter.OnItemClickListener {
-                override fun onItemClick(recipeId: Int) {
-                    openRecipeByRecipeId(recipeId)
-                }
-            })
+            adapter.setOnItemClickListener(
+                object : RecipesListAdapter.OnItemClickListener {
+                    override fun onItemClick(recipeId: Int) {
+                        openRecipeByRecipeId(recipeId)
+                    }
+                },
+            )
         }
     }
 
@@ -86,9 +90,10 @@ class FavoritesFragment : Fragment() {
 
     private fun openRecipeByRecipeId(recipeId: Int) {
         STUB.getRecipeById(recipeId)?.let { recipe ->
-            val bundle = Bundle().apply {
-                putParcelable(ARG_RECIPE, recipe)
-            }
+            val bundle =
+                Bundle().apply {
+                    putInt(ARG_RECIPE_ID, recipe.id)
+                }
 
             parentFragmentManager.commit {
                 setReorderingAllowed(true)

--- a/app/src/main/java/com/example/myrecipebook/ui/recipes/recipe/IngredientsAdapter.kt
+++ b/app/src/main/java/com/example/myrecipebook/ui/recipes/recipe/IngredientsAdapter.kt
@@ -8,9 +8,9 @@ import com.example.myrecipebook.model.Ingredient
 import java.math.BigDecimal
 import java.math.RoundingMode
 
-class IngredientsAdapter(private val ingredients: List<Ingredient>) :
-    RecyclerView.Adapter<IngredientsAdapter.ViewHolder>() {
-
+class IngredientsAdapter(
+    private val ingredients: List<Ingredient>,
+) : RecyclerView.Adapter<IngredientsAdapter.ViewHolder>() {
     private var portionCount: Int = 1
 
     fun updateIngredients(progress: Int) {
@@ -18,31 +18,37 @@ class IngredientsAdapter(private val ingredients: List<Ingredient>) :
         notifyDataSetChanged()
     }
 
-    inner class ViewHolder(private val binding: ItemIngredientBinding) :
-        RecyclerView.ViewHolder(binding.root) {
-
+    inner class ViewHolder(
+        private val binding: ItemIngredientBinding,
+    ) : RecyclerView.ViewHolder(binding.root) {
         fun bind(ingredient: Ingredient) {
-
-            val formattedQuantity = runCatching {
-                BigDecimal(ingredient.quantity.replace(",", "."))
-            }.getOrDefault(BigDecimal.ZERO)
-                .multiply(BigDecimal(portionCount))
-                .setScale(1, RoundingMode.HALF_UP)
-                .stripTrailingZeros()
-                .toPlainString()
+            val formattedQuantity =
+                runCatching {
+                    BigDecimal(ingredient.quantity.replace(",", "."))
+                }.getOrDefault(BigDecimal.ZERO)
+                    .multiply(BigDecimal(portionCount))
+                    .setScale(1, RoundingMode.HALF_UP)
+                    .stripTrailingZeros()
+                    .toPlainString()
 
             binding.tvQuantityWithUnit.text = "$formattedQuantity ${ingredient.unitOfMeasure}"
             binding.tvDescription.text = ingredient.description
         }
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
         val binding = ItemIngredientBinding.inflate(inflater, parent, false)
         return ViewHolder(binding)
     }
 
-    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+    override fun onBindViewHolder(
+        holder: ViewHolder,
+        position: Int,
+    ) {
         holder.bind(ingredients[position])
     }
 

--- a/app/src/main/java/com/example/myrecipebook/ui/recipes/recipe/MethodAdapter.kt
+++ b/app/src/main/java/com/example/myrecipebook/ui/recipes/recipe/MethodAdapter.kt
@@ -5,24 +5,33 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.example.myrecipebook.databinding.ItemMethodBinding
 
-class MethodAdapter(private val steps: List<String>) :
-    RecyclerView.Adapter<MethodAdapter.ViewHolder>() {
-
-    inner class ViewHolder(private val binding: ItemMethodBinding) :
-        RecyclerView.ViewHolder(binding.root) {
-
-        fun bind(step: String, position: Int) {
+class MethodAdapter(
+    private val steps: List<String>,
+) : RecyclerView.Adapter<MethodAdapter.ViewHolder>() {
+    inner class ViewHolder(
+        private val binding: ItemMethodBinding,
+    ) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(
+            step: String,
+            position: Int,
+        ) {
             binding.tvStep.text = "${position + 1}. $step"
         }
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
         val binding = ItemMethodBinding.inflate(inflater, parent, false)
         return ViewHolder(binding)
     }
 
-    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+    override fun onBindViewHolder(
+        holder: ViewHolder,
+        position: Int,
+    ) {
         holder.bind(steps[position], position)
     }
 

--- a/app/src/main/java/com/example/myrecipebook/ui/recipes/recipe/RecipeFragment.kt
+++ b/app/src/main/java/com/example/myrecipebook/ui/recipes/recipe/RecipeFragment.kt
@@ -48,8 +48,6 @@ class RecipeFragment : Fragment() {
         return binding.root
     }
 
-    private var isFavorite: Boolean = false
-
     override fun onViewCreated(
         view: View,
         savedInstanceState: Bundle?,
@@ -80,7 +78,7 @@ class RecipeFragment : Fragment() {
         }
     }
 
-    private fun updateFavoriteIcon() {
+    private fun updateFavoriteIcon(isFavorite: Boolean) {
         val iconRes =
             if (isFavorite) {
                 R.drawable.ic_heart_filled
@@ -133,8 +131,7 @@ class RecipeFragment : Fragment() {
                 addDividers()
             }
 
-            isFavorite = state.isFavorite
-            updateFavoriteIcon()
+            updateFavoriteIcon(state.isFavorite)
             binding.tvPortionsCount.text = state.portionCount.toString()
         }
     }

--- a/app/src/main/java/com/example/myrecipebook/ui/recipes/recipe/RecipeFragment.kt
+++ b/app/src/main/java/com/example/myrecipebook/ui/recipes/recipe/RecipeFragment.kt
@@ -74,20 +74,6 @@ class RecipeFragment : Fragment() {
         viewModel.loadRecipe(recipeId)
     }
 
-    private fun saveFavorites(favorites: Set<String>) {
-        val sharedPref = requireContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        with(sharedPref.edit()) {
-            putStringSet(FAVORITES_KEY, favorites)
-            apply()
-        }
-    }
-
-    private fun getFavorites(): MutableSet<String> {
-        val sharedPref = requireContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        val favorites = sharedPref.getStringSet(FAVORITES_KEY, null) ?: mutableSetOf()
-        return HashSet(favorites)
-    }
-
     private fun initFavoriteButton() {
         binding.ibFavorite.setOnClickListener {
             viewModel.onFavoritesClicked()
@@ -151,20 +137,6 @@ class RecipeFragment : Fragment() {
             updateFavoriteIcon()
             binding.tvPortionsCount.text = state.portionCount.toString()
         }
-    }
-
-    private fun initRecyclers() {
-        ingredientsAdapter = IngredientsAdapter(recipe.ingredients)
-
-        binding.rvIngredients.layoutManager = LinearLayoutManager(context)
-
-        binding.rvIngredients.adapter = ingredientsAdapter
-
-        binding.rvMethod.layoutManager = LinearLayoutManager(context)
-        val methodAdapter = MethodAdapter(recipe.method)
-        binding.rvMethod.adapter = methodAdapter
-
-        addDividers()
     }
 
     private fun addDividers() {

--- a/app/src/main/java/com/example/myrecipebook/ui/recipes/recipe/RecipeViewModel.kt
+++ b/app/src/main/java/com/example/myrecipebook/ui/recipes/recipe/RecipeViewModel.kt
@@ -1,12 +1,21 @@
 package com.example.myrecipebook.ui.recipes.recipe
 
+import android.app.Application
+import android.content.Context
 import android.util.Log
+import androidx.core.content.ContentProviderCompat.requireContext
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.example.myrecipebook.FAVORITES_KEY
+import com.example.myrecipebook.PREFS_NAME
+import com.example.myrecipebook.data.STUB
 import com.example.myrecipebook.model.Recipe
 
-class RecipeViewModel : ViewModel() {
+class RecipeViewModel(
+    application: Application,
+) : AndroidViewModel(application) {
     data class RecipeState(
         val recipe: Recipe? = null,
         val portionCount: Int = 1,
@@ -14,6 +23,8 @@ class RecipeViewModel : ViewModel() {
         val isLoading: Boolean = false,
         val error: Throwable? = null,
     )
+
+    private val sharedPref = application.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
     private val _state = MutableLiveData<RecipeState>()
 
@@ -26,5 +37,67 @@ class RecipeViewModel : ViewModel() {
 
     fun updateState(newState: RecipeState) {
         _state.value = newState
+    }
+
+    fun onFavoritesClicked() {
+        val currentState = _state.value ?: return
+        val currentRecipe = currentState.recipe ?: return
+
+        val favorites = getFavorites().toMutableSet()
+        val recipeIdStr = currentRecipe.id.toString()
+
+        val newFavoriteStatus = !currentState.isFavorite
+        if (newFavoriteStatus) {
+            favorites.add(recipeIdStr)
+        } else {
+            favorites.remove(recipeIdStr)
+        }
+        saveFavorites(favorites)
+
+        updateState(currentState.copy(isFavorite = newFavoriteStatus))
+    }
+
+    private fun saveFavorites(favorites: Set<String>) {
+        sharedPref.edit().putStringSet(FAVORITES_KEY, favorites).apply()
+    }
+
+    private fun getFavorites(): MutableSet<String> {
+        val favorites = sharedPref.getStringSet(FAVORITES_KEY, null) ?: mutableSetOf()
+        return HashSet(favorites)
+    }
+
+    fun loadRecipe(recipeId: Int) {
+        // TODO: 'Load from network'
+        val recipe = STUB.getRecipeById(recipeId)
+
+        if (recipe != null) {
+            val favorites = getFavorites()
+            val isFavorite = favorites.contains(recipe.id.toString())
+
+            val currentPortionCount = _state.value?.portionCount ?: 1
+
+            val newState =
+                _state.value?.copy(
+                    recipe = recipe,
+                    isFavorite = isFavorite,
+                    portionCount = currentPortionCount,
+                    isLoading = false,
+                ) ?: RecipeState(
+                    recipe = recipe,
+                    isFavorite = isFavorite,
+                    portionCount = currentPortionCount,
+                    isLoading = false,
+                )
+
+            updateState(newState)
+        } else {
+            val newState =
+                _state.value?.copy(
+                    error = Throwable("Recipe not found"),
+                    isLoading = false,
+                ) ?: RecipeState(error = Throwable("Recipe not found"), isLoading = false)
+
+            updateState(newState)
+        }
     }
 }

--- a/app/src/main/java/com/example/myrecipebook/ui/recipes/recipelist/RecipesListFragment.kt
+++ b/app/src/main/java/com/example/myrecipebook/ui/recipes/recipelist/RecipesListFragment.kt
@@ -13,35 +13,38 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.myrecipebook.ARG_CATEGORY_ID
 import com.example.myrecipebook.ARG_CATEGORY_IMAGE_URL
 import com.example.myrecipebook.ARG_CATEGORY_NAME
-import com.example.myrecipebook.ARG_RECIPE
+import com.example.myrecipebook.ARG_RECIPE_ID
 import com.example.myrecipebook.R
-import com.example.myrecipebook.ui.recipes.recipe.RecipeFragment
 import com.example.myrecipebook.data.STUB
 import com.example.myrecipebook.databinding.FragmentRecipesListBinding
 import com.example.myrecipebook.model.Recipe
+import com.example.myrecipebook.ui.recipes.recipe.RecipeFragment
 import java.io.IOException
 
 class RecipesListFragment : Fragment() {
-
     private var categoryId: Int? = null
     private var categoryName: String? = null
     private var categoryImageUrl: String? = null
     private var _binding: FragmentRecipesListBinding? = null
     private val binding
-        get() = _binding ?: throw IllegalStateException(
-            "Binding for FragmentRecipesListBinding must not be null."
-        )
+        get() =
+            _binding ?: throw IllegalStateException(
+                "Binding for FragmentRecipesListBinding must not be null.",
+            )
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View {
         _binding = FragmentRecipesListBinding.inflate(inflater, container, false)
         return binding.root
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
         super.onViewCreated(view, savedInstanceState)
 
         arguments?.let { bundle ->
@@ -77,20 +80,23 @@ class RecipesListFragment : Fragment() {
         binding.rvRecipes.layoutManager = LinearLayoutManager(context)
         binding.rvRecipes.adapter = adapter
 
-        adapter.setOnItemClickListener(object : RecipesListAdapter.OnItemClickListener {
-            override fun onItemClick(recipeId: Int) {
-                openRecipeByRecipeId(recipeId)
-            }
-        })
+        adapter.setOnItemClickListener(
+            object : RecipesListAdapter.OnItemClickListener {
+                override fun onItemClick(recipeId: Int) {
+                    openRecipeByRecipeId(recipeId)
+                }
+            },
+        )
     }
 
     private fun openRecipeByRecipeId(recipeId: Int) {
         Log.d("RecipesFragment", "Opening recipe ID: $recipeId")
 
         STUB.getRecipeById(recipeId)?.let { recipe ->
-            val bundle = Bundle().apply {
-                putParcelable(ARG_RECIPE, recipe)
-            }
+            val bundle =
+                Bundle().apply {
+                    putInt(ARG_RECIPE_ID, recipeId)
+                }
 
             parentFragmentManager.commit {
                 setReorderingAllowed(true)


### PR DESCRIPTION
1. Из фрагмента со списком рецептов теперь передается только recipeId.
2. Внутри RecipeViewModel.kt создал функцию loadRecipe(). Добавил комментарий TODO с сообщением 'load from network'. Метод вызывается один раз при создании фрагмента и служит для первичной инициализации стейта. Метод принимает id рецепта и присваивает полученный из хранилища рецепт соответствующему свойству стейта RecipeState.
3. Метод getFavorites() перенесен в RecipeViewModel.kt для первичной инициализации поля стейта isFavorite актуальным значением.
4. В loadRecipe:
- Проинициализировал свойство стейта isFavorite, используя getFavorites().
- Проинициализировал свойство стейта portionsCount, используя значение текущего стейта.
5. Перенес подписку на изменения LiveData в метод initUI().
6. Внутри RecipeViewModel.kt создал метод onFavoritesClicked().
7. Вынес saveFavorites() в RecipeViewModel.kt