### PR TITLE
RA-25: Обновлять RecipeState при изменении количества порций

### DIFF
--- a/app/src/main/java/com/example/myrecipebook/ui/recipes/recipe/IngredientsAdapter.kt
+++ b/app/src/main/java/com/example/myrecipebook/ui/recipes/recipe/IngredientsAdapter.kt
@@ -9,9 +9,17 @@ import java.math.BigDecimal
 import java.math.RoundingMode
 
 class IngredientsAdapter(
-    private val ingredients: List<Ingredient>,
+    private var ingredients: List<Ingredient>,
+    private var portionCount: Int,
 ) : RecyclerView.Adapter<IngredientsAdapter.ViewHolder>() {
-    private var portionCount: Int = 1
+    fun updateData(
+        newIngredients: List<Ingredient>,
+        newPortionCount: Int,
+    ) {
+        ingredients = newIngredients
+        portionCount = newPortionCount
+        notifyDataSetChanged()
+    }
 
     fun updateIngredients(progress: Int) {
         portionCount = progress

--- a/app/src/main/java/com/example/myrecipebook/ui/recipes/recipe/MethodAdapter.kt
+++ b/app/src/main/java/com/example/myrecipebook/ui/recipes/recipe/MethodAdapter.kt
@@ -6,7 +6,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.myrecipebook.databinding.ItemMethodBinding
 
 class MethodAdapter(
-    private val steps: List<String>,
+    private var steps: List<String>,
 ) : RecyclerView.Adapter<MethodAdapter.ViewHolder>() {
     inner class ViewHolder(
         private val binding: ItemMethodBinding,
@@ -33,6 +33,11 @@ class MethodAdapter(
         position: Int,
     ) {
         holder.bind(steps[position], position)
+    }
+
+    fun updateSteps(newSteps: List<String>) {
+        steps = newSteps
+        notifyDataSetChanged()
     }
 
     override fun getItemCount() = steps.size

--- a/app/src/main/java/com/example/myrecipebook/ui/recipes/recipe/RecipeViewModel.kt
+++ b/app/src/main/java/com/example/myrecipebook/ui/recipes/recipe/RecipeViewModel.kt
@@ -69,6 +69,11 @@ class RecipeViewModel(
         return HashSet(favorites)
     }
 
+    fun updatePortionCount(newPortionCount: Int) {
+        val currentState = _state.value ?: return
+        _state.value = currentState.copy(portionCount = newPortionCount)
+    }
+
     fun loadRecipe(recipeId: Int) {
         _state.value = _state.value?.copy(isLoading = true) ?: RecipeState(isLoading = true)
         // TODO: 'Load from network'
@@ -77,7 +82,6 @@ class RecipeViewModel(
         if (recipe != null) {
             val drawable: Drawable? =
                 try {
-                    // [CHANGED] Загрузка изображения перемещена из фрагмента сюда
                     val inputStream = getApplication<Application>().assets.open(recipe.imageUrl)
                     Drawable.createFromStream(inputStream, null)
                 } catch (e: IOException) {
@@ -117,7 +121,6 @@ class RecipeViewModel(
                     isLoading = false,
                     recipeImage = null,
                 )
-
             updateState(newState)
         }
     }

--- a/app/src/main/java/com/example/myrecipebook/ui/recipes/recipe/RecipeViewModel.kt
+++ b/app/src/main/java/com/example/myrecipebook/ui/recipes/recipe/RecipeViewModel.kt
@@ -76,7 +76,7 @@ class RecipeViewModel(
 
     fun loadRecipe(recipeId: Int) {
         _state.value = _state.value?.copy(isLoading = true) ?: RecipeState(isLoading = true)
-        // TODO: 'Load from network'
+        // TODO: 'Load from network.'
         val recipe = STUB.getRecipeById(recipeId)
 
         if (recipe != null) {


### PR DESCRIPTION
RA-25:
1. Удалена дублированная загрузка изображения прямо из assets
2. Отредактировано получение данных для адаптеров из recipeState.
3. portionsCount берется из стейта и передается в метод обновления ингредиентов в адаптере.
4. Внутри ViewModel создан метод updatePortionCount, который принимает целочисленное значение количества порций и обновляет этим значением стейт.
5. При обновлении прогресса SeekBar передает значение прогресса во ViewModel для обновления стейта.